### PR TITLE
Link parser output to drawing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,32 @@ This project contains a simple parser that extracts ordered process steps from a
 
 ## Running the parser
 
-Execute the parser directly to process the provided `example_input.txt`:
+Execute the parser directly to process the provided `example_input.txt` and
+write the ordered steps to a JSON file:
 
 ```bash
 python process_parser.py
 ```
 
-Example output:
+This command creates ``parsed_steps.json`` in the current directory.
 
-```
-[{'step': 'Üretim süreci aşağıdaki gibidir: Önce malzemeler karıştırma bölümünde iyice karıştırılır', 'order': 1}, {'step': 'Daha sonra karışım dolum makinesine aktarılır ve şişelere doldurulur', 'order': 2}, {'step': 'Sonra şişeler etiketleme hattına yönlendirilir', 'order': 3}, {'step': 'En son ürünler paketlenerek sevkiyata hazır hale getirilir', 'order': 4}]
+Example content of ``parsed_steps.json``:
+
+```json
+[
+  {"step": "Üretim süreci aşağıdaki gibidir: Önce malzemeler karıştırma bölümünde iyice karıştırılır", "order": 1},
+  {"step": "Daha sonra karışım dolum makinesine aktarılır ve şişelere doldurulur", "order": 2},
+  {"step": "Sonra şişeler etiketleme hattına yönlendirilir", "order": 3},
+  {"step": "En son ürünler paketlenerek sevkiyata hazır hale getirilir", "order": 4}
+]
 ```
 
 ## Generating a process map
 
-After parsing the text, you can produce a visual process map using `draw_process_map.py`:
+After obtaining ``parsed_steps.json``, you can produce a visual process map using ``draw_process_map.py``:
 
 ```bash
-python draw_process_map.py
+python draw_process_map.py parsed_steps.json
 ```
 
-The script reads `example_input.txt` by default and outputs `process_map.png` in the current directory. The `graphviz` Python package and Graphviz binaries are required for PNG generation.
+The script reads the JSON file and outputs ``process_map.png`` in the current directory. The ``graphviz`` Python package and Graphviz binaries are required for PNG generation.

--- a/draw_process_map.py
+++ b/draw_process_map.py
@@ -1,15 +1,16 @@
 import sys
 import os
-from process_parser import parse_process
+import json
 
 
 def draw_process_graph(input_file: str, output_path: str = "process_map.png") -> None:
-    """Generate a PNG visualization of the parsed process steps.
+    """Generate a PNG visualization of previously parsed process steps.
 
     Parameters
     ----------
     input_file : str
-        Path to the text file containing the process description.
+        Path to the JSON file containing the parsed process steps produced by
+        ``process_parser.py``.
     output_path : str, optional
         Desired output PNG file path. Defaults to ``process_map.png``.
     """
@@ -19,7 +20,8 @@ def draw_process_graph(input_file: str, output_path: str = "process_map.png") ->
         print("graphviz package not found. Please install it to generate the PNG.")
         return
 
-    steps = parse_process(input_file)
+    with open(input_file, "r", encoding="utf-8") as f:
+        steps = json.load(f)
     if not steps:
         print("No steps detected. Nothing to draw.")
         return
@@ -43,6 +45,6 @@ def draw_process_graph(input_file: str, output_path: str = "process_map.png") ->
 
 
 if __name__ == "__main__":
-    in_file = sys.argv[1] if len(sys.argv) > 1 else "example_input.txt"
+    in_file = sys.argv[1] if len(sys.argv) > 1 else "parsed_steps.json"
     out_file = sys.argv[2] if len(sys.argv) > 2 else "process_map.png"
     draw_process_graph(in_file, out_file)

--- a/process_parser.py
+++ b/process_parser.py
@@ -1,5 +1,7 @@
 from typing import List, Dict, Any
 import re
+import json
+import sys
 
 
 def parse_process(file_path: str) -> List[Dict[str, Any]]:
@@ -34,6 +36,23 @@ def parse_process(file_path: str) -> List[Dict[str, Any]]:
     return sorted(steps, key=lambda x: x["order"])
 
 
+def parse_and_save(input_file: str, output_file: str = "parsed_steps.json") -> None:
+    """Parse the given file and save the ordered steps as JSON.
+
+    Parameters
+    ----------
+    input_file : str
+        Path to the text file containing the raw process description.
+    output_file : str, optional
+        Destination JSON file. Defaults to ``parsed_steps.json``.
+    """
+    steps = parse_process(input_file)
+    with open(output_file, "w", encoding="utf-8") as out_f:
+        json.dump(steps, out_f, ensure_ascii=False, indent=2)
+    print(f"Parsed steps saved to {output_file}")
+
+
 if __name__ == "__main__":
-    parsed = parse_process("example_input.txt")
-    print(parsed)
+    in_file = sys.argv[1] if len(sys.argv) > 1 else "example_input.txt"
+    out_file = sys.argv[2] if len(sys.argv) > 2 else "parsed_steps.json"
+    parse_and_save(in_file, out_file)


### PR DESCRIPTION
## Summary
- save parsed steps to `parsed_steps.json`
- draw diagrams from the saved JSON
- clarify usage instructions

## Testing
- `python process_parser.py example_input.txt parsed_steps.json`
- `python draw_process_map.py parsed_steps.json` *(fails: graphviz missing)*