### PR TITLE
Add spaCy-based Turkish parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ This project contains a simple parser that extracts ordered process steps from a
 
 ## Running the parser
 
-Execute the parser directly to process the provided `example_input.txt` and
-write the ordered steps to a JSON file:
+Install dependencies and download the Turkish language model before running the parser:
+
+```bash
+pip install -r requirements.txt
+python -m spacy download tr_core_news_sm
+```
+
+Then execute the parser to process the provided `example_input.txt` and write the ordered steps to a JSON file:
 
 ```bash
 python process_parser.py

--- a/process_parser.py
+++ b/process_parser.py
@@ -1,7 +1,14 @@
 from typing import List, Dict, Any
-import re
 import json
 import sys
+import spacy
+
+try:
+    nlp = spacy.load("tr_core_news_sm")
+except OSError as exc:
+    raise RuntimeError(
+        "Turkish spaCy model not found. Run 'python -m spacy download tr_core_news_sm'"
+    ) from exc
 
 
 def parse_process(file_path: str) -> List[Dict[str, Any]]:
@@ -9,23 +16,34 @@ def parse_process(file_path: str) -> List[Dict[str, Any]]:
     with open(file_path, 'r', encoding='utf-8') as f:
         text = f.read()
 
-    sentences = [s.strip() for s in re.split(r'[\.\n]+', text) if s.strip()]
+    doc = nlp(text)
+    sentences = [sent.text.strip() for sent in doc.sents if sent.text.strip()]
 
     steps = []
     order_counter = 1
     for sent in sentences:
-        lower = sent.lower()
-        # simple keyword check to determine if sentence describes a step
-        if any(keyword in lower for keyword in ["karıştır", "dolum", "etiket", "paket"]):
-            if "önce" in lower or "ilk" in lower:
-                order_val = 1
-                order_counter = 2
-            elif "en son" in lower:
-                order_val = 1000  # temporary high value for final step
-            else:
-                order_val = order_counter
-                order_counter += 1
-            steps.append({"step": sent, "order": order_val})
+        sent_doc = nlp(sent)
+        # action phrase detection via imperative verbs
+        if not any(
+            tok.pos_ == "VERB" and "Imp" in tok.morph.get("Mood")
+            for tok in sent_doc
+        ):
+            continue
+
+        lemmas = {tok.lemma_.lower() for tok in sent_doc}
+        is_before = any(l in {"önce", "ilk"} for l in lemmas)
+        is_after = any(l in {"son", "sonra"} for l in lemmas)
+
+        if is_before:
+            order_val = 1
+            order_counter = max(order_counter, 2)
+        elif is_after:
+            order_val = 1000  # temporary high value for final step
+        else:
+            order_val = order_counter
+            order_counter += 1
+
+        steps.append({"step": sent, "order": order_val})
 
     max_order = max((s["order"] for s in steps if s["order"] != 1000), default=0)
     for s in steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+spacy
+
+tr_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/tr_core_news_sm-3.7.0/tr_core_news_sm-3.7.0.tar.gz


### PR DESCRIPTION
## Summary
- replace regex sentence splitting with spaCy sentence tokenizer
- detect imperative verbs and temporal expressions using spaCy
- document installing spaCy and the Turkish language model
- add requirements.txt listing spaCy and the tr model

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python process_parser.py example_input.txt` *(fails: ModuleNotFoundError: No module named 'spacy')*