### PR TITLE
Pin spaCy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For a Turkish version of this document, see [README_TR.md](README_TR.md).
 
 ## Installation
 
-Install the package and download the Turkish spaCy model:
+This project is tested with **spaCy 3.7**. Install the package and download the Turkish spaCy model:
 
 ```bash
 pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.8"
 dependencies = [
-    "spacy>=3.0",
+    "spacy~=3.7",
     "graphviz>=0.19",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-spacy
-
-tr_core_news_sm @ https://github.com/explosion/spacy-models/releases/download/tr_core_news_sm-3.7.0/tr_core_news_sm-3.7.0.tar.gz
+spacy~=3.7


### PR DESCRIPTION
## Summary
- pin `spacy~=3.7`
- document the spaCy version requirement

## Testing
- `python -m py_compile *.py`
