### PR TITLE
Add HTML map output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ draw-process-map cleaned_steps.json
 ```
 
 The script reads the JSON file and outputs ``process_map.png`` in the current directory. The ``graphviz`` Python package and Graphviz binaries are required for PNG generation.
+
+To create an interactive HTML version instead, pass ``--format html`` and open the resulting file in your browser:
+
+```bash
+draw-process-map cleaned_steps.json process_map.html --format html
+```
+
+See the generated [process_map.html](process_map.html) for an example.

--- a/process_map.html
+++ b/process_map.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Process Map Example</title>
+  <script src="https://unpkg.com/vis-network@9.1.2/dist/vis-network.min.js"></script>
+  <style>#mynetwork{width:100%;height:400px;border:1px solid lightgray;}</style>
+</head>
+<body>
+<h3>Process Map Example</h3>
+<div id="mynetwork"></div>
+<script type="text/javascript">
+var nodes = new vis.DataSet([
+  {id:1, label:'1. İlk adım'},
+  {id:2, label:'2. İkinci adım'}
+]);
+var edges = new vis.DataSet([{from:1, to:2}]);
+var network = new vis.Network(document.getElementById('mynetwork'), {nodes:nodes, edges:edges}, {layout:{hierarchical:false}});
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ dependencies = [
 [project.scripts]
 smart-process-parse = "process_parser:parse_and_save"
 smart-step-extract = "semantic_step_extractor:main"
-draw-process-map = "draw_process_map:draw_process_graph"
+draw-process-map = "draw_process_map:main"


### PR DESCRIPTION
## Summary
- generate interactive HTML maps using pyvis
- support `--format` CLI option
- expose new CLI via entrypoint
- document HTML usage and include example file

## Testing
- `python draw_process_map.py --help`
- `bash setup.sh` *(fails: Could not install packages)*