### PR TITLE
Add offline build script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ pip install .
 python -m spacy download tr_core_news_sm
 ```
 
+### Building a zip archive
+
+If you need an offline bundle, run the helper script to package all
+dependencies and the Turkish spaCy model:
+
+```bash
+bash scripts/build_zip.sh
+```
+
+This creates `dist/smart-process-mapper.zip` containing the project files and
+installed libraries.
+
+### Download and extraction
+
+Download the zip from the releases page or build it yourself as shown above.
+Then extract it and run the tools from the `package` directory:
+
+```bash
+unzip smart-process-mapper.zip
+cd package
+python process_parser.py example_input.txt parsed_steps.json
+```
+
 ## Running the parser
 
 To extract ordered steps from a text file, run:

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+PKG_DIR="$DIST_DIR/package"
+
+# clean previous build
+rm -rf "$DIST_DIR"
+mkdir -p "$PKG_DIR"
+
+echo "Installing Python dependencies into $PKG_DIR"
+pip install -r "$ROOT_DIR/requirements.txt" --target "$PKG_DIR"
+
+# download Turkish spaCy model
+echo "Downloading spaCy model to local package"
+python -m spacy download tr_core_news_sm --direct --target "$PKG_DIR"
+
+# copy project scripts
+cp "$ROOT_DIR"/*.py "$PKG_DIR"/
+cp -r "$ROOT_DIR/ui" "$PKG_DIR/"
+cp "$ROOT_DIR/README.md" "$PKG_DIR/"
+cp "$ROOT_DIR/README_TR.md" "$PKG_DIR/"
+cp "$ROOT_DIR/example_input.txt" "$PKG_DIR/"
+
+cd "$DIST_DIR"
+ZIP_NAME="smart-process-mapper.zip"
+zip -r "$ZIP_NAME" package
+
+echo "Created $DIST_DIR/$ZIP_NAME"


### PR DESCRIPTION
## Summary
- add `scripts/build_zip.sh` for building a self-contained zip
- document download/extraction steps in the README

## Testing
- `bash -n scripts/build_zip.sh`
- `python -m py_compile process_parser.py semantic_step_extractor.py draw_process_map.py ui/app.py`
- `bash scripts/build_zip.sh` *(fails: Could not install deps without network)*