### PR TITLE
Use external Turkish model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ For a Turkish version of this document, see [README_TR.md](README_TR.md).
 
 ## Installation
 
-This project is tested with **spaCy 3.7**. Install the package and download the Turkish spaCy model:
+This project is tested with **spaCy 3.7**. Clone the Turkish model repository and install the medium model before installing this package:
 
 ```bash
+git clone https://github.com/turkish-nlp-suite/turkish-spacy-models
+pip install -e turkish-spacy-models/tr_core_news_md
+python -m spacy link tr_core_news_md tr_core_news_md
 pip install .
-python -m spacy download tr_core_news_sm
 ```
 
 ### Building a zip archive

--- a/process_parser.py
+++ b/process_parser.py
@@ -2,13 +2,17 @@ from typing import List, Dict, Any
 import argparse
 import json
 import spacy
+import warnings
 
 try:
-    nlp = spacy.load("tr_core_news_sm")
-except OSError as exc:
-    raise RuntimeError(
-        "Turkish spaCy model not found. Run 'python -m spacy download tr_core_news_sm'"
-    ) from exc
+    nlp = spacy.load("tr_core_news_md")
+except OSError:
+    warnings.warn(
+        "Turkish spaCy model 'tr_core_news_md' not found. Using blank tokenizer"
+    )
+    nlp = spacy.blank("tr")
+    if "sentencizer" not in nlp.pipe_names:
+        nlp.add_pipe("sentencizer")
 
 
 def parse_process(file_path: str) -> List[Dict[str, Any]]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ streamlit
 pyvis
 graphviz>=0.20.1
 
-# Not:
-# After installing, run this to download Turkish NLP model:
-#   python -m spacy download tr_core_news_sm
+# After installing these packages, obtain the Turkish NLP model from
+# https://github.com/turkish-nlp-suite/turkish-spacy-models
+# and install it with:
+#   pip install -e turkish-spacy-models/tr_core_news_md
+#   python -m spacy link tr_core_news_md tr_core_news_md

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -13,8 +13,13 @@ echo "Installing Python dependencies into $PKG_DIR"
 pip install -r "$ROOT_DIR/requirements.txt" --target "$PKG_DIR"
 
 # download Turkish spaCy model
-echo "Downloading spaCy model to local package"
-python -m spacy download tr_core_news_sm --direct --target "$PKG_DIR"
+echo "Adding Turkish spaCy model if available"
+if [ -d "$ROOT_DIR/turkish-spacy-models/tr_core_news_md" ]; then
+    pip install -e "$ROOT_DIR/turkish-spacy-models/tr_core_news_md" --target "$PKG_DIR"
+    python -m spacy link tr_core_news_md tr_core_news_md
+else
+    echo "Turkish model not found; proceeding without it"
+fi
 
 # copy project scripts
 cp "$ROOT_DIR"/*.py "$PKG_DIR"/

--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -1,13 +1,17 @@
 import argparse
 import json
 import spacy
+import warnings
 
 try:
-    nlp = spacy.load("tr_core_news_sm")
-except OSError as exc:
-    raise RuntimeError(
-        "Turkish spaCy model not found. Run 'python -m spacy download tr_core_news_sm'"
-    ) from exc
+    nlp = spacy.load("tr_core_news_md")
+except OSError:
+    warnings.warn(
+        "Turkish spaCy model 'tr_core_news_md' not found. Using blank tokenizer"
+    )
+    nlp = spacy.blank("tr")
+    if "sentencizer" not in nlp.pipe_names:
+        nlp.add_pipe("sentencizer")
 
 def extract_steps(text):
     """Extract simplified action steps from free-form Turkish process text."""

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 pip install -r requirements.txt
-python -m spacy download tr_core_news_sm
+
+# Optional local installation of the Turkish spaCy model
+if [ -d turkish-spacy-models/tr_core_news_md ]; then
+    pip install -e turkish-spacy-models/tr_core_news_md
+    python -m spacy link tr_core_news_md tr_core_news_md
+else
+    echo "Turkish model not installed. Clone turkish-spacy-models if needed."
+fi


### PR DESCRIPTION
## Summary
- load `tr_core_news_md` if available
- fall back to blank tokenizer when the model is missing
- show install instructions for `tr_core_news_md`
- adjust build and setup scripts

## Testing
- `python -m compileall -q .`