### PR TITLE
Align spaCy version with model requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ For a Turkish version of this document, see [README_TR.md](README_TR.md).
 
 ## Installation
 
-This project is tested with **spaCy 3.7**. Install the Turkish NLP model from Hugging Face before installing this package:
+This project requires **spaCy >=3.4.2,<3.5.0**. Install the Turkish NLP model from Hugging Face before installing this package:
 
 ```bash
 pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.8"
 dependencies = [
-    "spacy~=3.7",
+    "spacy>=3.4.2,<3.5.0",
     "graphviz>=0.19",
     "streamlit",
     "pyvis",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy~=3.7
+spacy>=3.4.2,<3.5.0
 streamlit
 pyvis
 graphviz>=0.20.1


### PR DESCRIPTION
## Summary
- relax spaCy requirement to match the Turkish model
- document new spaCy version range in README

## Testing
- `python process_parser.py example_input.txt output.json` *(fails: ModuleNotFoundError: No module named 'spacy')*