### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-spacy>=3.4.2,<3.5.0
+spacy==3.4.2
+numpy==1.23.5
+thinc==8.1.10
 streamlit
 pyvis
 graphviz>=0.20.1


### PR DESCRIPTION
## Summary
- pin spacy to 3.4.2
- add numpy and thinc requirements

## Testing
- `n/a`