### PR TITLE
Fix app.py for running from ui folder

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import streamlit as st
 from semantic_step_extractor import extract_steps
 from pyvis.network import Network


### PR DESCRIPTION
## Summary
- update imports in `ui/app.py` so it can be executed from the `ui` directory

## Testing
- `python -m py_compile ui/app.py`
- `streamlit run ui/app.py --server.headless true` *(fails: command not found)*