### PR TITLE
Add warning when no steps extracted

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -29,6 +29,10 @@ else:
 
 if text:
     steps = extract_steps(text)
+    if not steps:
+        st.warning(
+            "No steps were extracted. Ensure the spaCy model is installed and the text is a valid Turkish process description."
+        )
     st.subheader("Extracted Steps")
     for idx, step in enumerate(steps, 1):
         st.write(f"{idx}. {step}")


### PR DESCRIPTION
## Summary
- warn the user if no steps are produced by `extract_steps`

## Testing
- `pytest -q`