### PR TITLE
Add UI startup scripts and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ cd ui
 streamlit run app.py          # run inside the ui folder
 ```
 
+On Windows systems you can simply double-click `start_ui.bat` to launch the web
+interface. Unix users may run `./start_ui.sh` if the script is available.
+
 These commands assume the packages in `requirements.txt` and the `tr_core_news_md` spaCy model are installed.
 
 ## Citation

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -22,6 +22,8 @@ cp -r "$ROOT_DIR/ui" "$PKG_DIR/"
 cp "$ROOT_DIR/README.md" "$PKG_DIR/"
 cp "$ROOT_DIR/README_TR.md" "$PKG_DIR/"
 cp "$ROOT_DIR/example_input.txt" "$PKG_DIR/"
+cp "$ROOT_DIR/start_ui.bat" "$PKG_DIR/"
+[ -f "$ROOT_DIR/start_ui.sh" ] && cp "$ROOT_DIR/start_ui.sh" "$PKG_DIR/"
 
 cd "$DIST_DIR"
 ZIP_NAME="smart-process-mapper.zip"

--- a/start_ui.bat
+++ b/start_ui.bat
@@ -1,0 +1,6 @@
+@echo off
+set VENV_DIR=%~dp0venv
+if exist "%VENV_DIR%\Scripts\activate.bat" (
+    call "%VENV_DIR%\Scripts\activate.bat"
+)
+streamlit run "%~dp0\ui\app.py"

--- a/start_ui.sh
+++ b/start_ui.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+HERE="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$HERE/venv/bin/activate" ]; then
+    . "$HERE/venv/bin/activate"
+fi
+streamlit run "$HERE/ui/app.py"
+


### PR DESCRIPTION
## Summary
- add `start_ui.bat` and optional `start_ui.sh` for launching the Streamlit UI
- document these helpers in the README
- include the batch and shell files when creating the distribution zip

## Testing
- `python -m py_compile *.py ui/*.py`
- `bash -n scripts/build_zip.sh start_ui.sh`