### PR TITLE
Improve step extraction logic

### DIFF
--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import re
 import spacy
 import warnings
 
@@ -16,31 +17,66 @@ except OSError:
     if "sentencizer" not in nlp.pipe_names:
         nlp.add_pipe("sentencizer")
 
-def extract_steps(text):
-    """Extract simplified action steps from free-form Turkish process text."""
+def regex_based_extract_steps(text: str) -> list[str]:
+    """Return a list of ordered steps for numbered instructions."""
+    pattern = re.compile(r"^\s*\d+[\.)]\s*(.*)")
+    steps: list[str] = []
+    current: list[str] = []
+
+    for line in text.splitlines():
+        match = pattern.match(line)
+        if match:
+            if current:
+                steps.append(" ".join(current).strip())
+                current = []
+            step = match.group(1).strip()
+            if step:
+                current.append(step)
+        elif current:
+            stripped = line.strip()
+            if stripped:
+                current.append(stripped)
+
+    if current:
+        steps.append(" ".join(current).strip())
+
+    return steps
+
+
+def semantic_extract_steps(text: str) -> list[str]:
+    """Extract action phrases from free-form Turkish text using spaCy."""
     doc = nlp(text)
-    steps = []
-    seen = set()
+    steps: list[str] = []
+    seen: set[str] = set()
 
     for sent in doc.sents:
         for token in sent:
             if token.pos_ != "VERB" or token.dep_ not in {"ROOT", "conj"}:
                 continue
-            obj = None
+
+            obj_token = None
             for child in token.children:
                 if child.dep_ in {"obj", "obl"} and child.pos_ in {"NOUN", "PROPN"}:
-                    obj = child.lemma_
+                    obj_token = child
                     break
-            # nominalize the verb lemma
-            lemma = token.lemma_
-            if lemma.endswith("mek") or lemma.endswith("mak"):
-                lemma = lemma[:-3] + "me"
-            phrase = f"{obj.capitalize() + ' ' if obj else ''}{lemma}"
-            if phrase not in seen:
+
+            verb = token.lemma_
+            if verb.endswith("mek") or verb.endswith("mak"):
+                verb = verb[:-3]
+
+            phrase = f"{obj_token.lemma_ + ' ' if obj_token else ''}{verb}".strip()
+            if phrase and phrase not in seen:
                 seen.add(phrase)
                 steps.append(phrase)
 
     return steps
+
+def extract_steps(text: str) -> list[str]:
+    """Extract ordered or semantic steps depending on input format."""
+    numbered_pattern = re.compile(r"^\s*\d+[\.)]", re.MULTILINE)
+    if numbered_pattern.search(text):
+        return regex_based_extract_steps(text)
+    return semantic_extract_steps(text)
 
 def main(in_file: str = "example_input.txt", out_file: str = "cleaned_steps.json") -> None:
     """Read the input file, extract steps and save them as JSON."""


### PR DESCRIPTION
## Summary
- add regex and semantic extraction modes
- auto-switch based on input format

## Testing
- `pytest -q` *(fails: no tests)*
- `python semantic_step_extractor.py example_input.txt tmp_out.json` *(fails: ModuleNotFoundError: No module named 'spacy')*