### PR TITLE
Automate LLM model setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib
 pyvis
 graphviz>=0.20.1
 transformers>=4.30.0
+huggingface-hub>=0.16.0
 
 # After installing these packages, install the Turkish NLP model from
 # Hugging Face with:

--- a/start_ui.bat
+++ b/start_ui.bat
@@ -25,6 +25,9 @@ if %ERRORLEVEL% neq 0 goto install_fail
 python -m spacy link tr_core_news_md tr_core_news_md >> "%BASE_DIR%install.log" 2>&1
 if %ERRORLEVEL% neq 0 goto install_fail
 
+rem Download Kocdigital LLM weights if not already cached
+"%VENV_DIR%\Scripts\huggingface-cli.exe" download KOCDIGITAL/Kocdigital-LLM-8b-v0.1 >> "%BASE_DIR%install.log" 2>&1
+
 rem Record installed packages
 pip list > "%BASE_DIR%installed_packages.log"
 


### PR DESCRIPTION
## Summary
- add `huggingface-hub` to dependencies
- install missing modules automatically and download LLM weights at runtime
- download Kocdigital LLM in the Windows helper script

## Testing
- `pytest -q`
- `python -m py_compile semantic_step_extractor.py`