### PR TITLE
Fix wheel URL mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ For a Turkish version of this document, see [README_TR.md](README_TR.md).
 This project was tested only with **Python 3.10**.
 The tested versions are spaCy 3.4.2, numpy 1.23.5 and thinc 8.1.10. Install the Turkish NLP model from Hugging Face before installing this package:
 ```bash
-pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl
+pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl
 pip install -r requirements.txt
 pip install .
 ```
+
+Both `setup.sh` and the Windows launcher `start_ui.bat` fetch the model using
+the same URL, so manual installation is optional on those platforms.
 
 To leverage the optional Kocdigital language model, download the weights using
 `huggingface-cli` and ensure `transformers` is installed from the requirements.

--- a/process_parser.py
+++ b/process_parser.py
@@ -10,7 +10,7 @@ except OSError:
     warnings.warn(
         "spaCy model 'tr_core_news_md' is not installed. "
         "Install it with "
-        "`pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl` "
+        "`pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl` "
         "and rerun. Falling back to a blank Turkish pipeline."
     )
     nlp = spacy.blank("tr")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ huggingface-hub>=0.16.0
 
 # After installing these packages, install the Turkish NLP model from
 # Hugging Face with:
-#   pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl
+#   pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -14,7 +14,7 @@ pip install -r "$ROOT_DIR/requirements.txt" --target "$PKG_DIR"
 
 # download Turkish spaCy model
 echo "Adding Turkish spaCy model from Hugging Face"
-pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl --target "$PKG_DIR"
+pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl --target "$PKG_DIR"
 
 # copy project scripts
 cp "$ROOT_DIR"/*.py "$PKG_DIR"/

--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -57,7 +57,7 @@ except OSError:
     warnings.warn(
         "spaCy model 'tr_core_news_md' is not installed. "
         "Install it with "
-        "`pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl` "
+        "`pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl` "
         "and rerun. Falling back to a blank Turkish pipeline."
     )
     nlp = spacy.blank("tr")

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 pip install -r requirements.txt
-pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl
+pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl
 python -m spacy link tr_core_news_md tr_core_news_md
 # Optionally download the KOCDIGITAL LLM weights for offline use
 # huggingface-cli download KOCDIGITAL/Kocdigital-LLM-8b-v0.1


### PR DESCRIPTION
## Summary
- sync spaCy model download URL across scripts and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`