### PR TITLE
Add HF cache option for semantic_step_extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To leverage the optional Kocdigital language model, download the weights using
 `huggingface-cli` and ensure `transformers` is installed from the requirements.
 The Windows launcher caches these weights under `hf_cache` next to the script
 by setting the `HF_HOME` environment variable before invoking `huggingface-cli`.
+Alternatively, supply the `--hf-home` option when running `smart-step-extract`
+to use a custom cache directory.
 
 Run `pip install -r requirements.txt` before executing the CLI tools or launching the Streamlit UI to ensure all dependencies are available.
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -89,6 +89,9 @@ parsed = parse_process("example_input.txt")
 Windows başlangıç betiği indirilen ağırlıkları `HF_HOME` değişkeni ile script dizinine oluşturulan `hf_cache` klasörüne kaydeder,
 adım çıkarma işlemini LLM ile gerçekleştirmek için şu komutu çalıştırabilirsiniz:
 
+`smart-step-extract` komutunda `--hf-home` parametresi ile önbellek klasörünü
+belirtebilirsiniz.
+
 ```bash
 python semantic_step_extractor.py example_input.txt cleaned_steps.json --llm
 ```


### PR DESCRIPTION
## Summary
- allow specifying `--hf-home` on the CLI
- propagate the option to set `HF_HOME`
- load Kocdigital model with `local_files_only` when `HF_HOME` is set
- document the new option in README files

## Testing
- `python -m py_compile semantic_step_extractor.py`
- `python -m py_compile process_parser.py draw_process_map.py`