### PR TITLE
Add CLI main wrappers

### DIFF
--- a/process_parser.py
+++ b/process_parser.py
@@ -77,7 +77,8 @@ def parse_and_save(input_file: str, output_file: str = "parsed_steps.json") -> N
     print(f"Parsed steps saved to {output_file}")
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """CLI entry point for ``smart-process-parse``."""
     parser = argparse.ArgumentParser(
         description="Parse a Turkish process description and save ordered steps"
     )
@@ -95,3 +96,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     parse_and_save(args.input_file, args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [project.scripts]
-smart-process-parse = "process_parser:parse_and_save"
+smart-process-parse = "process_parser:main"
 smart-step-extract = "semantic_step_extractor:main"
 draw-process-map = "draw_process_map:main"
 

--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -203,7 +203,7 @@ def extract_steps(text: str, use_llm: bool = False) -> list[str]:
         return regex_based_extract_steps(text)
     return semantic_extract_steps(text)
 
-def main(
+def run(
     in_file: str = "example_input.txt",
     out_file: str = "cleaned_steps.json",
     use_llm: bool = False,
@@ -224,7 +224,9 @@ def main(
         json.dump(steps, out_f, ensure_ascii=False, indent=2)
     print(f"Cleaned steps saved to {out_file}")
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """CLI entry point for ``smart-step-extract``."""
     parser = argparse.ArgumentParser(
         description="Extract simplified steps from a Turkish process text."
     )
@@ -251,4 +253,7 @@ if __name__ == "__main__":
         help="Directory to use as HF_HOME for cached models",
     )
     args = parser.parse_args()
-    main(args.input_file, args.output_file, args.llm, args.hf_home)
+    run(args.input_file, args.output_file, args.llm, args.hf_home)
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- expose command-line entrypoints via new `main()` functions
- rename internal runner in `semantic_step_extractor.py`
- adjust script entrypoints in `pyproject.toml`

## Testing
- `python -m py_compile process_parser.py semantic_step_extractor.py draw_process_map.py`
- `pytest -q`