### PR TITLE
Document HF_HOME usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ by setting the `HF_HOME` environment variable before invoking `huggingface-cli`.
 Alternatively, supply the `--hf-home` option when running `smart-step-extract`
 to use a custom cache directory.
 
+### Setting `HF_HOME`
+
+Hugging Face models are cached under `HF_HOME`. Define this variable before
+running the command-line tools or `start_ui.bat` if you want a custom cache
+location:
+
+```bash
+# Windows CMD
+set HF_HOME=C:\hf_cache
+
+# PowerShell
+$env:HF_HOME="C:\hf_cache"
+
+# Unix shells
+export HF_HOME=/path/to/hf_cache
+```
+
+The provided batch script uses the existing `HF_HOME` value when present,
+otherwise it defaults to a local `hf_cache` directory.
+
 Run `pip install -r requirements.txt` before executing the CLI tools or launching the Streamlit UI to ensure all dependencies are available.
 
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -97,3 +97,20 @@ python semantic_step_extractor.py example_input.txt cleaned_steps.json --llm
 ```
 
 `--llm` parametresi verilmezse spaCy tabanlı çıkarıcı kullanılır.
+
+### HF_HOME Değişkeni
+
+Hugging Face modellerinin nereye indirileceğini `HF_HOME` ortam değişkeni ile
+belirleyebilirsiniz. Komut satırındaki araçları veya `start_ui.bat` dosyasını
+çalıştırmadan önce değişkeni şu şekilde ayarlayın:
+
+```bash
+# Windows
+set HF_HOME=C:\hf_cache
+
+# Linux/macOS
+export HF_HOME=/path/to/hf_cache
+```
+
+Batch scripti tanımlı bir `HF_HOME` varsa onu kullanır, aksi halde kendi
+klasöründe `hf_cache` oluşturur.


### PR DESCRIPTION
## Summary
- explain how to set `HF_HOME` in README
- add equivalent instructions to Turkish README

## Testing
- `pytest -q`