### PR TITLE
Set Transformers cache to HF_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ export HF_HOME=/path/to/hf_cache
 
 The provided batch script uses the existing `HF_HOME` value when present,
 otherwise it defaults to a local `hf_cache` directory.
+`TRANSFORMERS_CACHE` is also set to the same location so the Transformers
+library can find the cached weights.
 
 Run `pip install -r requirements.txt` before executing the CLI tools or launching the Streamlit UI to ensure all dependencies are available.
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -34,6 +34,8 @@ export HF_HOME=/path/to/hf_cache
 ```
 
 Sağlanan batch betiği var olan `HF_HOME` değerini kullanır, aksi takdirde yerel bir `hf_cache` dizinine varsayılan olarak indirir.
+`TRANSFORMERS_CACHE` değişkeni de aynı konuma ayarlanarak Transformers
+kütüphanesinin önbelleği doğru yerde aramasını sağlar.
 
 CLI araçlarını veya Streamlit arayüzünü çalıştırmadan önce `pip install -r requirements.txt` komutunu çalıştırarak tüm bağımlılıkların yüklü olduğundan emin olun.
 

--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -216,6 +216,7 @@ def run(
     """
     if hf_home:
         os.environ["HF_HOME"] = hf_home
+        os.environ["TRANSFORMERS_CACHE"] = hf_home
 
     with open(in_file, "r", encoding="utf-8") as f:
         text = f.read()

--- a/start_ui.bat
+++ b/start_ui.bat
@@ -6,10 +6,12 @@ set BASE_DIR=%~dp0
 set VENV_DIR=%BASE_DIR%venv
 set FLAG_FILE=%VENV_DIR%\installed.flag
 if not defined HF_HOME set HF_HOME=%BASE_DIR%hf_cache
+if not defined TRANSFORMERS_CACHE set TRANSFORMERS_CACHE=%HF_HOME%
 
 echo BASE_DIR=%BASE_DIR%
 echo VENV_DIR=%VENV_DIR%
 echo HF_HOME=%HF_HOME%
+echo TRANSFORMERS_CACHE=%TRANSFORMERS_CACHE%
 
 rem Skip venv creation if marker exists but still verify dependencies
 echo Checking for installation flag at %FLAG_FILE%...


### PR DESCRIPTION
## Summary
- set `TRANSFORMERS_CACHE` in `start_ui.bat`
- propagate the variable from CLI in `semantic_step_extractor.py`
- mention the new behaviour in English and Turkish READMEs

## Testing
- `bash setup.sh` *(fails: cannot access network)*