### PR TITLE
Clarify HF_HOME usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ $env:HF_HOME="C:\hf_cache"
 export HF_HOME=/path/to/hf_cache
 ```
 
+Always point `HF_HOME` to the **top-level** cache directory. Do not set it to a
+subfolder like `hub` or `snapshots`. `start_ui.bat` appends
+`hub\models--KOCDIGITAL--Kocdigital-LLM-8b-v0.1` when verifying that the model
+weights are present, so pointing `HF_HOME` to one of those subdirectories will
+cause the check to fail.
+
 The provided batch script uses the existing `HF_HOME` value when present,
 otherwise it defaults to a local `hf_cache` directory.
 `TRANSFORMERS_CACHE` is also set to the same location so the Transformers

--- a/README_TR.md
+++ b/README_TR.md
@@ -33,6 +33,8 @@ $env:HF_HOME="C:\hf_cache"
 export HF_HOME=/path/to/hf_cache
 ```
 
+`HF_HOME` her zaman Hugging Face önbellek klasörünün **üst dizinine** işaret etmelidir. `hub` veya `snapshots` gibi alt klasörler kullanılmamalıdır. `start_ui.bat` betiği modeli kontrol ederken `hub\models--KOCDIGITAL--Kocdigital-LLM-8b-v0.1` yolunu eklediği için `HF_HOME`'u bu alt dizinlerden birine yönlendirmek denetimin başarısız olmasına neden olur.
+
 Sağlanan batch betiği var olan `HF_HOME` değerini kullanır, aksi takdirde yerel bir `hf_cache` dizinine varsayılan olarak indirir.
 `TRANSFORMERS_CACHE` değişkeni de aynı konuma ayarlanarak Transformers
 kütüphanesinin önbelleği doğru yerde aramasını sağlar.


### PR DESCRIPTION
## Summary
- clarify that HF_HOME must reference the root Hugging Face cache directory
- warn against pointing HF_HOME to a nested folder
- mention start_ui.bat appends `hub\models--KOCDIGITAL--Kocdigital-LLM-8b-v0.1`

## Testing
- `git status --short`