### PR TITLE
Add log exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 
 # Logs
 *.log
+install.log
+installed_packages.log
 
 # Distribution / packaging
 build/


### PR DESCRIPTION
## Summary
- ignore install.log and installed_packages.log

## Testing
- `bash -x ./setup.sh` *(fails: Could not install packages)*