### PR TITLE
Remove deprecated spaCy link commands

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,4 @@
 pip install -r requirements.txt
 pip install https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-1.0-py3-none-any.whl
-python -m spacy link tr_core_news_md tr_core_news_md
 # Optionally download the KOCDIGITAL LLM weights for offline use
 # huggingface-cli download KOCDIGITAL/Kocdigital-LLM-8b-v0.1

--- a/start_ui.bat
+++ b/start_ui.bat
@@ -81,14 +81,6 @@ if not defined SKIP_VENV_CREATION (
         echo Local package installed.
     )
 
-    echo Linking spaCy model...
-    python -m spacy link tr_core_news_md tr_core_news_md >> "%BASE_DIR%install.log" 2>&1
-    if %ERRORLEVEL% neq 0 (
-        echo spaCy model link failed (%ERRORLEVEL%)
-        goto install_fail
-    ) else (
-        echo spaCy model linked.
-    )
 
     echo Checking for Kocdigital LLM weights...
     if not exist "%HF_HOME%\hub\models--KOCDIGITAL--Kocdigital-LLM-8b-v0.1" (


### PR DESCRIPTION
## Summary
- drop `python -m spacy link` from Windows batch and shell setup scripts
- rely on loading the model directly via `spacy.load("tr_core_news_md")`

## Testing
- `bash setup.sh` *(fails: could not access network to install dependencies)*