### PR TITLE
Remove runtime pip installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ pip install .
 Both `setup.sh` and the Windows launcher `start_ui.bat` fetch the model using
 the same URL, so manual installation is optional on those platforms.
 
-To leverage the optional Kocdigital language model, download the weights using
-`huggingface-cli` and ensure `transformers` is installed from the requirements.
+To leverage the optional Kocdigital language model, install the
+`transformers` and `huggingface_hub` packages from the requirements and download
+the weights using `huggingface-cli`.
 The Windows launcher caches these weights under `hf_cache` next to the script
 by setting the `HF_HOME` environment variable before invoking `huggingface-cli`.
 Alternatively, supply the `--hf-home` option when running `smart-step-extract`
@@ -89,8 +90,9 @@ This command creates ``parsed_steps.json`` in the current directory.
 
 ### Using the Kocdigital LLM
 
-If the optional [KOCDIGITAL/Kocdigital-LLM-8b-v0.1](https://huggingface.co/KOCDIGITAL/Kocdigital-LLM-8b-v0.1) model is installed,
-steps can be extracted with the LLM instead of spaCy:
+If the optional [KOCDIGITAL/Kocdigital-LLM-8b-v0.1](https://huggingface.co/KOCDIGITAL/Kocdigital-LLM-8b-v0.1) model is installed and
+both `transformers` and `huggingface_hub` are available, steps can be extracted
+with the LLM instead of spaCy:
 
 ```bash
 smart-step-extract example_input.txt cleaned_steps.json --llm

--- a/README_TR.md
+++ b/README_TR.md
@@ -15,7 +15,7 @@ pip install .
 
 Hem `setup.sh` hem de Windows için `start_ui.bat` betiği modeli aynı URL'den indirir, bu nedenle bu platformlarda manuel kurulum isteğe bağlıdır.
 
-İsteğe bağlı Kocdigital dil modelinden yararlanmak için ağırlıkları `huggingface-cli` kullanarak indirin ve `requirements.txt` içerisindeki `transformers` paketinin kurulu olduğundan emin olun.
+İsteğe bağlı Kocdigital dil modelinden yararlanmak için `requirements.txt`'teki `transformers` ve `huggingface_hub` paketlerini kurup ağırlıkları `huggingface-cli` ile indirin.
 Windows başlangıç betiği bu ağırlıkları `HF_HOME` ortam değişkenini ayarlayarak scriptin yanındaki `hf_cache` klasörüne kaydeder.
 Alternatif olarak `smart-step-extract` komutunu çalıştırırken `--hf-home` seçeneği ile özel bir önbellek dizini belirtebilirsiniz.
 
@@ -70,7 +70,7 @@ Bu komut bulunduğunuz dizinde ``parsed_steps.json`` dosyasını oluşturur.
 
 ### Kocdigital LLM kullanımı
 
-İsteğe bağlı [KOCDIGITAL/Kocdigital-LLM-8b-v0.1](https://huggingface.co/KOCDIGITAL/Kocdigital-LLM-8b-v0.1) modeli kuruluysa, adımlar LLM ile spaCy yerine çıkarılabilir:
+İsteğe bağlı [KOCDIGITAL/Kocdigital-LLM-8b-v0.1](https://huggingface.co/KOCDIGITAL/Kocdigital-LLM-8b-v0.1) modeli kurulu ve `transformers` ile `huggingface_hub` paketleri yüklüyse, adımlar LLM ile spaCy yerine çıkarılabilir:
 ```bash
 smart-step-extract example_input.txt cleaned_steps.json --llm
 ```

--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -4,8 +4,6 @@ import logging
 import os
 import re
 import spacy
-import subprocess
-import sys
 import warnings
 from typing import Optional
 
@@ -15,42 +13,25 @@ try:
         AutoModelForCausalLM,
         pipeline,
     )
-except Exception:  # pragma: no cover - transformers is optional
+except Exception as exc:  # pragma: no cover - transformers is optional
     AutoTokenizer = None
     AutoModelForCausalLM = None
     pipeline = None
-    try:  # attempt silent install if missing
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "transformers", "huggingface_hub"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        from transformers import (
-            AutoTokenizer,
-            AutoModelForCausalLM,
-            pipeline,
-        )
-    except Exception as exc:  # pragma: no cover - installation failed
-        logging.warning("Could not import transformers: %s", exc)
-        AutoTokenizer = None
-        AutoModelForCausalLM = None
-        pipeline = None
+    logging.warning(
+        "transformers not available (%s). Install 'transformers' and "
+        "'huggingface_hub' with pip to enable LLM features.",
+        exc,
+    )
 
 try:
     from huggingface_hub import snapshot_download
-except Exception:
+except Exception as exc:
     snapshot_download = None
-    if AutoTokenizer:  # install only if transformers succeeded
-        try:
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "huggingface_hub"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            from huggingface_hub import snapshot_download
-        except Exception as exc:  # pragma: no cover - installation failed
-            logging.warning("Could not import huggingface_hub: %s", exc)
-            snapshot_download = None
+    logging.warning(
+        "huggingface_hub not available (%s). Install it with pip to enable "
+        "LLM features.",
+        exc,
+    )
 
 try:
     nlp = spacy.load("tr_core_news_md")


### PR DESCRIPTION
## Summary
- prevent semantic_step_extractor from attempting runtime package installation
- document manual installation requirement for Transformers and huggingface_hub

## Testing
- `bash setup.sh` *(fails: Could not connect to proxy)*