### PR TITLE
Clarify manual LLM dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ pip install .
 Both `setup.sh` and the Windows launcher `start_ui.bat` fetch the model using
 the same URL, so manual installation is optional on those platforms.
 
-To leverage the optional Kocdigital language model, install the
-`transformers` and `huggingface_hub` packages from the requirements and download
-the weights using `huggingface-cli`.
+To leverage the optional Kocdigital language model, first install the
+`transformers` and `huggingface_hub` packages and download the weights using
+`huggingface-cli`. These dependencies are **not** installed automatically, so be
+sure they are available before enabling the LLM features.
 The Windows launcher caches these weights under `hf_cache` next to the script
 by setting the `HF_HOME` environment variable before invoking `huggingface-cli`.
 Alternatively, supply the `--hf-home` option when running `smart-step-extract`

--- a/README_TR.md
+++ b/README_TR.md
@@ -15,7 +15,7 @@ pip install .
 
 Hem `setup.sh` hem de Windows için `start_ui.bat` betiği modeli aynı URL'den indirir, bu nedenle bu platformlarda manuel kurulum isteğe bağlıdır.
 
-İsteğe bağlı Kocdigital dil modelinden yararlanmak için `requirements.txt`'teki `transformers` ve `huggingface_hub` paketlerini kurup ağırlıkları `huggingface-cli` ile indirin.
+İsteğe bağlı Kocdigital dil modelinden yararlanmak için önce `transformers` ve `huggingface_hub` paketlerini kurup ağırlıkları `huggingface-cli` ile indirin. Bu bağımlılıklar otomatik olarak kurulmaz, LLM özelliğini etkinleştirmeden önce mevcut olduklarından emin olun.
 Windows başlangıç betiği bu ağırlıkları `HF_HOME` ortam değişkenini ayarlayarak scriptin yanındaki `hf_cache` klasörüne kaydeder.
 Alternatif olarak `smart-step-extract` komutunu çalıştırırken `--hf-home` seçeneği ile özel bir önbellek dizini belirtebilirsiniz.
 

--- a/semantic_step_extractor.py
+++ b/semantic_step_extractor.py
@@ -17,20 +17,18 @@ except Exception as exc:  # pragma: no cover - transformers is optional
     AutoTokenizer = None
     AutoModelForCausalLM = None
     pipeline = None
-    logging.warning(
-        "transformers not available (%s). Install 'transformers' and "
-        "'huggingface_hub' with pip to enable LLM features.",
-        exc,
+    warnings.warn(
+        "transformers not available (%s). Install the 'transformers' and "
+        "'huggingface_hub' packages manually to enable LLM features." % exc
     )
 
 try:
     from huggingface_hub import snapshot_download
 except Exception as exc:
     snapshot_download = None
-    logging.warning(
-        "huggingface_hub not available (%s). Install it with pip to enable "
-        "LLM features.",
-        exc,
+    warnings.warn(
+        "huggingface_hub not available (%s). Install the package manually "
+        "to enable LLM features." % exc
     )
 
 try:


### PR DESCRIPTION
## Summary
- warn about missing `transformers` or `huggingface_hub` rather than relying on auto install
- document that these packages must be installed beforehand for optional LLM features

## Testing
- `python -m py_compile semantic_step_extractor.py process_parser.py draw_process_map.py ui/app.py`